### PR TITLE
fix: Keep list of already finalized targets

### DIFF
--- a/src/cmake/modules/MatlabTools.cmake
+++ b/src/cmake/modules/MatlabTools.cmake
@@ -765,7 +765,7 @@ function (basis_add_mex_file TARGET_NAME)
   endif ()
   # finalize target
   if (ARGN_FINAL)
-    basis_build_mex_file(${TARGET_UID})
+    basis_finalize_targets (${TARGET_UID})
   endif ()
   # add target to list of targets
   basis_set_project_property (APPEND PROPERTY TARGETS "${TARGET_UID}")
@@ -1149,7 +1149,7 @@ function (basis_add_mcc_target TARGET_NAME)
   )
   # finalize target
   if (ARGN_FINAL)
-    basis_build_mcc_target(${TARGET_UID})
+    basis_finalize_targets (${TARGET_UID})
   endif ()
   # add target to list of targets
   basis_set_project_property (APPEND PROPERTY TARGETS "${TARGET_UID}")

--- a/src/cmake/modules/ProjectTools.cmake
+++ b/src/cmake/modules/ProjectTools.cmake
@@ -2010,6 +2010,8 @@ macro (basis_project_initialize)
   basis_set_project_property (PROPERTY BUNDLE_LINK_DIRS  "")
   # see add_executable(), add_library()
   basis_set_project_property (PROPERTY TARGETS "")
+  # see basis_finalize_targets()
+  basis_set_project_property (PROPERTY FINALIZED_TARGETS "")
   # see basis_add_*() functions
   basis_set_project_property (PROPERTY EXPORT_TARGETS                "")
   basis_set_project_property (PROPERTY INSTALL_EXPORT_TARGETS        "")

--- a/src/cmake/modules/TargetTools.cmake
+++ b/src/cmake/modules/TargetTools.cmake
@@ -1571,7 +1571,7 @@ function (basis_add_script TARGET_NAME)
   )
   # finalize target
   if (ARGN_FINAL)
-    basis_build_script(${TARGET_UID})
+    basis_finalize_targets (${TARGET_UID})
   endif ()
   # add target to list of targets
   basis_set_project_property (APPEND PROPERTY TARGETS "${TARGET_UID}")
@@ -1623,26 +1623,37 @@ function (basis_finalize_targets)
       ${TARGET_UID_Basis_pm}
     )
   endif ()
+  basis_get_project_property (FINALIZED_TARGETS PROPERTY FINALIZED_TARGETS)
+  if (FINALIZED_TARGETS)
+    list (REMOVE_ITEM TARGETS ${FINALIZED_TARGETS})
+  endif ()
+  if (BASIS_DEBUG)
+    message (
+      "** basis_finalize_targets:"
+      "\n     TARGETS:   [${TARGETS}]"
+      "\n     FINALIZED: [${FINALIZED_TARGETS}]"
+    )
+  endif ()
   foreach (TARGET_UID ${TARGETS})
-    if (NOT TARGET _${TARGET_UID})
-      get_target_property (BASIS_TYPE ${TARGET_UID} BASIS_TYPE)
-      if (BASIS_TYPE MATCHES "^EXECUTABLE$|^(SHARED|MODULE)_LIBRARY$")
-        if (BASIS_INSTALL_RPATH AND NOT CMAKE_SKIP_RPATH)
-          # Only if BASIS is allowed to take care of the INSTALL_RPATH property
-          # and the use of this property was not disabled by the project
-          basis_set_target_install_rpath (${TARGET_UID})
-        endif ()
-      elseif (BASIS_TYPE MATCHES "SCRIPT_LIBRARY")
-        basis_build_script_library (${TARGET_UID})
-      elseif (BASIS_TYPE MATCHES "SCRIPT")
-        basis_build_script (${TARGET_UID})
-      elseif (BASIS_TYPE MATCHES "MEX")
-        basis_build_mex_file (${TARGET_UID})
-      elseif (BASIS_TYPE MATCHES "MCC")
-        basis_build_mcc_target (${TARGET_UID})
+    get_target_property (BASIS_TYPE ${TARGET_UID} BASIS_TYPE)
+    if (BASIS_TYPE MATCHES "^EXECUTABLE$|^(SHARED|MODULE)_LIBRARY$")
+      if (BASIS_INSTALL_RPATH AND NOT CMAKE_SKIP_RPATH)
+        # Only if BASIS is allowed to take care of the INSTALL_RPATH property
+        # and the use of this property was not disabled by the project
+        basis_set_target_install_rpath (${TARGET_UID})
       endif ()
+    elseif (BASIS_TYPE MATCHES "SCRIPT_LIBRARY")
+      basis_build_script_library (${TARGET_UID})
+    elseif (BASIS_TYPE MATCHES "SCRIPT")
+      basis_build_script (${TARGET_UID})
+    elseif (BASIS_TYPE MATCHES "MEX")
+      basis_build_mex_file (${TARGET_UID})
+    elseif (BASIS_TYPE MATCHES "MCC")
+      basis_build_mcc_target (${TARGET_UID})
     endif ()
+    list (APPEND FINALIZED_TARGETS ${TARGET_UID})
   endforeach ()
+  basis_set_project_property (PROPERTY FINALIZED_TARGETS ${FINALIZED_TARGETS})
 endfunction ()
 
 # ============================================================================
@@ -2559,7 +2570,7 @@ function (basis_add_script_library TARGET_NAME)
   endif ()
   # finalize target
   if (ARGN_FINAL)
-    basis_build_script_library(${TARGET_UID})
+    basis_finalize_targets (${TARGET_UID})
   endif ()
   # add target to list of targets
   basis_set_project_property (APPEND PROPERTY TARGETS "${TARGET_UID}")


### PR DESCRIPTION
This also prevents to re-finalize C++ targets, i.e., to call `basis_set_install_rpath` more than once which would just slow down the configure process.
