### PR TITLE
fix: Require at least CMake 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@
 # A command such as the one above is required to build MEX-files using the
 # MEX script and MATLAB Compiler targets.
 
-cmake_minimum_required (VERSION 2.8.4)
+cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
 
 # ----------------------------------------------------------------------------
 # BASIS Utilities settings from BASISConfig.cmake

--- a/test/cmake/test_target_properties.cmake
+++ b/test/cmake/test_target_properties.cmake
@@ -3,7 +3,7 @@
 # @brief Test basis_set_target_properites() and basis_get_target_properties().
 ##############################################################################
 
-cmake_minimum_required (VERSION 2.8.4)
+cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
 
 find_package (BASIS REQUIRED)
 basis_use_package (BASIS)


### PR DESCRIPTION
The minimum required CMake version for CMake BASIS 3.3.0 will be CMake 2.8.12. Previous releases are missing some important features and had a couple of bugs. Also, 2.8.12 is the last 2.x version of CMake and the current version is 3.5 already.
