### PR TITLE
Updated Project so that a user can finish the Quickstart section

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -66,7 +66,6 @@ Configure the build system using CMake 2.8.4 or a more recent version:
 - Press ``c`` to configure the project.
 - Change ``CMAKE_INSTALL_PREFIX`` to ``~/local``.
 - Set options ``BUILD_APPLICATIONS`` and ``BUILD_EXAMPLE`` to ``ON``.
-- Make sure that option ``BUILD_PROJECT_TOOL`` is enabled.
 - Press ``g`` to generate the Makefiles and exit ``ccmake``.
 
 Build and install BASIS
@@ -100,16 +99,16 @@ Using the C or TC shell (csh/tcsh):
 
 .. code-block:: bash
     
-    setenv PATH "~/local/bin:${PATH}"
-    setenv BASIS_EXAMPLE_DIR "~/local/share/basis/example"
+    setenv PATH "${HOME}/local/bin:${PATH}"
+    setenv BASIS_EXAMPLE_DIR "${HOME}/local/share/basis/example"
     setenv HELLOBASIS_RSC_DIR "${BASIS_EXAMPLE_DIR}/hellobasis"
 
 Using the Bourne Again SHell (bash):
 
 .. code-block:: bash
     
-    export PATH="~/local/bin:${PATH} "
-    export BASIS_EXAMPLE_DIR="~/local/share/basis/example"
+    export PATH="${HOME}/local/bin:${PATH} "
+    export BASIS_EXAMPLE_DIR="${HOME}/local/share/basis/example"
     export HELLOBASIS_RSC_DIR="${BASIS_EXAMPLE_DIR}/hellobasis"
 
 
@@ -120,7 +119,7 @@ Create a new and empty project as follows:
 
 .. code-block:: bash
     
-    basisproject create --name HelloBasis --description "This is a BASIS project."
+    basisproject create --name HelloBasis --description "This is a BASIS project." \
                  --root ~/local/src/hellobasis
 
 The next command demonstrates that you can modify a previously created project by using the
@@ -341,7 +340,7 @@ Create a Top Level Project
 
 .. code-block:: bash
 
-    export TOPLEVEL_DIR="~/local/src/HelloTopLevel"
+    export TOPLEVEL_DIR="${HOME}/local/src/HelloTopLevel"
     basisproject create --name HelloTopLevel --description "This is a BASIS TopLevel project. It demonstrates how easy it is to create a simple BASIS project."  --root ${TOPLEVEL_DIR}  --toplevel
 
 Create a sub-project Containing a Library
@@ -351,13 +350,13 @@ Create a sub-project module similarly to how helloBasis was created earlier.
 
 .. code-block:: bash
 
-    export MODA_DIR="~/local/src/HelloTopLevel/modules/moda"
+    export MODA_DIR="${HOME}/local/src/HelloTopLevel/modules/moda"
     basisproject create --name moda --description "Subproject library to be used elsewhere" --root ${MODA_DIR} --module --include
     cp ${HELLOBASIS_RSC_DIR}/moda.cxx ${MODA_DIR}/src/
     mkdir ${MODA_DIR}/include/moda
     cp ${HELLOBASIS_RSC_DIR}/moda.h ${MODA_DIR}/include/moda/
 
-Add the following line to ``${MODB_DIR}/src/CMakeLists.txt`` under the section "library target(s)":
+Add the following line to ``${MODA_DIR}/src/CMakeLists.txt`` under the section "library target(s)":
 
 .. code-block:: cmake
     
@@ -374,13 +373,13 @@ Create a sub-project module similarly to how helloBasis was created earlier.
     
     export MODB_DIR="${TOPLEVEL_DIR}/modules/modb"
     basisproject create --name modb --description "User example subproject executable utility repository that uses the library"  --root ${MODB_DIR} --module --src --use moda
-    cp ${HELLOBASIS_RSC_DIR}/userprog.cpp ${MODB_DIR}/src/
+    cp ${HELLOBASIS_RSC_DIR}/userprog.cxx ${MODB_DIR}/src/
 
 Add the following line to ``${MODB_DIR}/src/CMakeLists.txt`` under the section "executable target(s)":
 
 .. code-block:: cmake
     
-    basis_add_executable(userprog.cpp)
+    basis_add_executable(userprog.cxx)
     basis_target_link_libraries(userprog moda)
 
 

--- a/example/hellobasis/moda.cxx
+++ b/example/hellobasis/moda.cxx
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include <hellotoplevel/moda.h>
+#include <moda/moda.h>
 
 namespace hellotoplevel {
 

--- a/example/hellobasis/userprog.cxx
+++ b/example/hellobasis/userprog.cxx
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <hellotoplevel/moda.h>
+#include <moda/moda.h>
 
 int main(int, char**)
 {

--- a/src/cmake/modules/TargetTools.cmake
+++ b/src/cmake/modules/TargetTools.cmake
@@ -1617,11 +1617,13 @@ function (basis_finalize_targets)
     basis_make_target_uid (TARGET_UID_basis_sh basis_sh)
     basis_make_target_uid (TARGET_UID_basis_py basis_py)
     basis_make_target_uid (TARGET_UID_Basis_pm Basis_pm)
-    list (REMOVE_ITEM TARGETS
-      ${TARGET_UID_basis_sh}
-      ${TARGET_UID_basis_py}
-      ${TARGET_UID_Basis_pm}
-    )
+    if (TARGETS)
+      list (REMOVE_ITEM TARGETS
+        ${TARGET_UID_basis_sh}
+        ${TARGET_UID_basis_py}
+        ${TARGET_UID_Basis_pm}
+      )
+    endif ()
   endif ()
   basis_get_project_property (FINALIZED_TARGETS PROPERTY FINALIZED_TARGETS)
   if (FINALIZED_TARGETS)


### PR DESCRIPTION
Explanation of (the non-obvious) changes:
- BUILD_PROJECT_TOOL does not exist anymore
- when setting variables, $HOME is preferable to "~". I ran into the following error: "cp: cannot stat ‘~/local/share/basis/example/hellobasis/helloc++.cxx’: No such file or directory", which worked when I replaced ~ with $HOME
- moda.h is in the moda module, not hellotoplevel
- Not sure why, but the line "list (REMOVE_ITEM TARGETS" led to the below cmake error. There's probably a better fix than surrounding the statement with an if

CMake Error at /home/forte/local/share/basis/modules/TargetTools.cmake:1620 (list):
  list sub-command REMOVE_ITEM requires list to be present.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cmake-basis/basis/599)

<!-- Reviewable:end -->
