### PR TITLE
Fix build in MSYS2 using mingw64 subsystem

### DIFF
--- a/include/basis/test.h
+++ b/include/basis/test.h
@@ -44,7 +44,7 @@
 #ifdef GTEST_HAS_PTHREAD
 #  undef GTEST_HAS_PTHREAD
 #endif
-#if HAVE_PTHREAD
+#if HAVE_PTHREAD && !(defined(__MINGW__) || defined(__MINGW32__))
 #  define GTEST_HAS_PTHREAD 1
 #else
 #  define GTEST_HAS_PTHREAD 0

--- a/src/utilities/cxx/stdio.cxx
+++ b/src/utilities/cxx/stdio.cxx
@@ -46,6 +46,14 @@ void get_terminal_size(int& lines, int& columns)
             columns = csbi.dwSize.X;
             lines   = csbi.dwSize.Y;
         }
+    #else
+        struct winsize w;
+        if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0) {
+            columns = w.ws_col;
+            lines   = w.ws_row;
+        }
+    #endif
+    #ifdef __MSC_VER
         if (columns == 0) {
             char* COLUMNS;
             size_t sz;
@@ -63,11 +71,6 @@ void get_terminal_size(int& lines, int& columns)
             }
         }
     #else
-        struct winsize w;
-        if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0) {
-            columns = w.ws_col;
-            lines   = w.ws_row;
-        }
         if (columns == 0) {
             const char* COLUMNS = getenv("COLUMNS");
             if (COLUMNS) columns = atoi(COLUMNS);


### PR DESCRIPTION
Fixes build with MinGW GCC compiler instead of Microsoft Visual Studio on Windows.

Closes  #631.